### PR TITLE
EXOGTN-2002 Display name of a node is splitted incorrectly in some cases

### DIFF
--- a/webui/core/src/main/java/org/exoplatform/webui/core/UITree.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/core/UITree.java
@@ -286,8 +286,13 @@ public class UITree extends UIComponent {
         StringBuilder builder = new StringBuilder();
 
         // if field's length > max field's length then cut field value
-        if ((fieldValue.length() > getMaxTitleCharacter()) && (getMaxTitleCharacter() != 0)) {
-            fieldValue = fieldValue.substring(0, getMaxTitleCharacter() - 3) + "...";
+        int maxTitleCharacter = getMaxTitleCharacter();
+        if ((fieldValue.length() > maxTitleCharacter) && (maxTitleCharacter != 0)) {
+          int lastSpace = fieldValue.indexOf(" ", maxTitleCharacter);
+            if (lastSpace > 0)
+              fieldValue= fieldValue.substring(0, lastSpace) + "...";
+            else
+              fieldValue = fieldValue.substring(0, getMaxTitleCharacter() - 3) + "...";
         }
 
         if (escapeHTML_) {

--- a/webui/core/src/main/java/org/exoplatform/webui/core/UITree.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/core/UITree.java
@@ -289,10 +289,10 @@ public class UITree extends UIComponent {
         int maxTitleCharacter = getMaxTitleCharacter();
         if ((fieldValue.length() > maxTitleCharacter) && (maxTitleCharacter != 0)) {
           int lastSpace = fieldValue.indexOf(" ", maxTitleCharacter);
-            if (lastSpace > 0)
-              fieldValue= fieldValue.substring(0, lastSpace) + "...";
-            else
-              fieldValue = fieldValue.substring(0, getMaxTitleCharacter() - 3) + "...";
+          if (lastSpace > 0)
+            fieldValue= fieldValue.substring(0, lastSpace) + "...";
+          else
+            fieldValue = fieldValue.substring(0, getMaxTitleCharacter() - 3) + "...";
         }
 
         if (escapeHTML_) {

--- a/webui/core/src/main/java/org/exoplatform/webui/core/UITree.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/core/UITree.java
@@ -22,6 +22,7 @@ package org.exoplatform.webui.core;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
+import org.apache.commons.lang.StringEscapeUtils;
 
 import org.exoplatform.commons.serialization.api.annotations.Serialized;
 import org.exoplatform.commons.utils.HTMLEntityEncoder;
@@ -286,14 +287,12 @@ public class UITree extends UIComponent {
         StringBuilder builder = new StringBuilder();
 
         // if field's length > max field's length then cut field value
+        fieldValue = StringEscapeUtils.unescapeHtml(fieldValue);
         int maxTitleCharacter = getMaxTitleCharacter();
         if ((fieldValue.length() > maxTitleCharacter) && (maxTitleCharacter != 0)) {
-          int lastSpace = fieldValue.indexOf(" ", maxTitleCharacter);
-          if (lastSpace > 0)
-            fieldValue= fieldValue.substring(0, lastSpace) + "...";
-          else
-            fieldValue = fieldValue.substring(0, getMaxTitleCharacter() - 3) + "...";
+          fieldValue = fieldValue.substring(0, getMaxTitleCharacter() - 3) + "...";
         }
+        fieldValue = StringEscapeUtils.escapeHtml(fieldValue);
 
         if (escapeHTML_) {
             fieldValue = fieldValue != null ? HTMLEntityEncoder.getInstance().encode(fieldValue) : fieldValue;


### PR DESCRIPTION
Fix description: in case the display name of a node is too long, we will cut it from the first character to the first space after maximum length, and add "..." at the end. Otherwise, if it's a word, we will remove 3 last characters and replace by "..."
