### PR TITLE
GTNPORTAL-3402 - Custom password policies

### DIFF
--- a/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIAccountEditInputSet.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIAccountEditInputSet.java
@@ -35,7 +35,7 @@ import org.exoplatform.webui.form.UIFormInputBase;
 import org.exoplatform.webui.form.UIFormInputSet;
 import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
+import org.exoplatform.webui.form.validator.PasswordPolicyValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
 import org.exoplatform.webui.form.validator.UserConfigurableValidator;
@@ -77,12 +77,12 @@ public class UIAccountEditInputSet extends UIFormInputSet {
         uiCheckbox.setOnChange("ToggleChangePassword", "UIUserInfo");
         addUIFormInput(uiCheckbox);
         UIFormInputBase<String> uiInput = new UIFormStringInput(PASSWORD1X, null, null)
-                .setType(UIFormStringInput.PASSWORD_TYPE).addValidator(PasswordStringLengthValidator.class, 6, 30)
+                .setType(UIFormStringInput.PASSWORD_TYPE).addValidator(PasswordPolicyValidator.class)
                 .addValidator(MandatoryValidator.class);
         uiInput.setRendered(false);
         addUIFormInput(uiInput);
         uiInput = new UIFormStringInput(PASSWORD2X, null, null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30);
+                .addValidator(MandatoryValidator.class).addValidator(PasswordPolicyValidator.class);
         uiInput.setRendered(false);
         addUIFormInput(uiInput);
     }

--- a/webui/core/pom.xml
+++ b/webui/core/pom.xml
@@ -59,4 +59,24 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                  <argLine>-Xms512m -Xmx512m</argLine>
+                  <systemProperties>
+                      <property>
+                          <name>gatein.conf.dir</name>
+                          <value>${project.build.testOutputDirectory}/conf</value>
+                      </property>
+                  </systemProperties>
+              </configuration>
+          </plugin>
+      </plugins>
+
+  </build>
+  
 </project>

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/PasswordPolicyValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/PasswordPolicyValidator.java
@@ -1,0 +1,62 @@
+package org.exoplatform.webui.form.validator;
+
+import org.exoplatform.webui.form.UIFormInput;
+
+/**
+ * This validator checks the password against a policy named "passwordpolicy" from the validator configuration.
+ * If no such entry is available, it validates that the password has a minimum of 6 and maximum of 30 chars, which
+ * was the GateIn behavior before the introduction of this validator.
+ *
+ * The entries in the configuration file should look like this:
+ * <pre>
+ *      gatein.validators.passwordpolicy.length.min=5
+ *      gatein.validators.passwordpolicy.length.max=50
+ *      gatein.validators.passwordpolicy.regexp=...
+ *      gatein.validators.passwordpolicy.format.message=Minimum 5 chars, max 50 chars, upper/lower case required, number required.
+ * </pre>
+ *
+ * @see org.exoplatform.webui.form.validator.UserConfigurableValidator
+ * @see org.exoplatform.webui.form.validator.PasswordStringLengthValidator
+ * @author <a href="mailto:jpkroehling@redhat.com">Juraci Paixão Kröhling</a>
+ */
+public class PasswordPolicyValidator extends AbstractValidator {
+
+    private static final String POLICY_CONFIG_ENTRY = "passwordpolicy";
+    private AbstractValidator validator;
+
+    public PasswordPolicyValidator() {
+
+        // if we have a policy configured, we use it, otherwise, we do the simple verification
+        // as we had before this change
+        if (UserConfigurableValidator.getConfigurationNames().contains(POLICY_CONFIG_ENTRY)) {
+            validator = new UserConfigurableValidator(POLICY_CONFIG_ENTRY, null);
+        } else {
+            validator = new PasswordStringLengthValidator(6, 30);
+        }
+
+    }
+
+    @Override
+    protected String getMessageLocalizationKey() {
+        return validator.getMessageLocalizationKey();
+    }
+
+    @Override
+    public void validate(UIFormInput uiInput) throws Exception {
+        // this is needed, as the UserConfigurableValidator calls this one directly, which then skips the isValid
+        validator.validate(uiInput);
+    }
+
+    @Override
+    protected boolean isValid(String value, UIFormInput uiInput) {
+        // this is needed, as the StringLengthValidator calls this one
+        return validator.isValid(value, uiInput);
+    }
+
+    @Override
+    protected Object[] getMessageArgs(String value, UIFormInput uiInput) throws Exception {
+        // this is needed for proper formatting of the message, for the StringLengthValidator
+        return validator.getMessageArgs(value, uiInput);
+    }
+
+}

--- a/webui/core/src/main/java/org/exoplatform/webui/form/validator/UserConfigurableValidator.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/validator/UserConfigurableValidator.java
@@ -26,11 +26,12 @@ package org.exoplatform.webui.form.validator;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
-
 import org.exoplatform.commons.serialization.api.annotations.Serialized;
 import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.portal.pom.config.Utils;
@@ -202,6 +203,19 @@ public class UserConfigurableValidator extends MultipleConditionsValidator {
                 messages.addMessage(localizationKey, new Object[] { label, configuration.formatMessage });
             }
         }
+    }
+
+    /**
+     * Provides a way to query what are the currently known policies from the configuration files. For instance,
+     * if an entry exists as gatein.validators.mycompanypasspolicy.regexp , then there's a configuration called
+     * "mycompanypasspolicy", and this will be returned by this method.
+     *
+     * Note: the built-in configurations are <b>not</b> returned by this method, only the custom-provided ones.
+     *
+     * @return a set containing all known configuration key names.
+     */
+    public static final Set<String> getConfigurationNames() {
+        return Collections.unmodifiableSet(configurations.keySet());
     }
 
     private static class ValidatorConfiguration {

--- a/webui/core/src/test/java/org/exoplatform/webui/test/validator/TestWebuiValidator.java
+++ b/webui/core/src/test/java/org/exoplatform/webui/test/validator/TestWebuiValidator.java
@@ -18,9 +18,8 @@ package org.exoplatform.webui.test.validator;
 
 import java.util.List;
 import java.util.Locale;
-
+import java.util.Set;
 import junit.framework.TestCase;
-
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.exception.MessageException;
@@ -32,6 +31,7 @@ import org.exoplatform.webui.form.validator.IdentifierValidator;
 import org.exoplatform.webui.form.validator.NameValidator;
 import org.exoplatform.webui.form.validator.NumberFormatValidator;
 import org.exoplatform.webui.form.validator.NumberRangeValidator;
+import org.exoplatform.webui.form.validator.PasswordPolicyValidator;
 import org.exoplatform.webui.form.validator.PositiveNumberFormatValidator;
 import org.exoplatform.webui.form.validator.ResourceValidator;
 import org.exoplatform.webui.form.validator.SpecialCharacterValidator;
@@ -87,6 +87,42 @@ public class TestWebuiValidator extends TestCase {
         assertFalse(expected(validator, uiInput));
         uiInput.setValue("28/09/2011 10:59:59");
         assertFalse(expected(validator, uiInput));
+    }
+
+    public void testCustomPasswordValidator() {
+        Validator validator = new UserConfigurableValidator("mycompanypasspolicy");
+        assertFalse(expected(validator, "ABC123ABC!@#")); // missing lowercase
+        assertFalse(expected(validator, "12312312312312312312")); // more than 20 chars
+        assertFalse(expected(validator, "123123123")); // mising upper/lower case
+        assertFalse(expected(validator, "A1a")); // less than 6 chars
+        assertFalse(expected(validator, "ABC123")); // missing lowercase
+        assertFalse(expected(validator, "abc123")); // missing uppercase
+        assertTrue(expected(validator, "ABC123abc"));
+        assertTrue(expected(validator, "abc123ABC"));
+        assertTrue(expected(validator, "abcABC123"));
+        assertTrue(expected(validator, "123abcABC"));
+        assertTrue(expected(validator, "123abcABC!@#"));
+    }
+
+    public void testPasswordPolicyValidator() {
+        Validator validator = new PasswordPolicyValidator();
+        assertFalse(expected(validator, "ABC123ABC!@#")); // missing lowercase
+        assertFalse(expected(validator, "12312312312312312312")); // more than 20 chars
+        assertFalse(expected(validator, "123123123")); // mising upper/lower case
+        assertFalse(expected(validator, "A1a")); // less than 6 chars
+        assertFalse(expected(validator, "ABC123")); // missing lowercase
+        assertFalse(expected(validator, "abc123")); // missing uppercase
+        assertTrue(expected(validator, "ABC123abc"));
+        assertTrue(expected(validator, "abc123ABC"));
+        assertTrue(expected(validator, "abcABC123"));
+        assertTrue(expected(validator, "123abcABC"));
+        assertTrue(expected(validator, "123abcABC!@#"));
+    }
+    
+    public void testCheckAvaibleConfigurations() {
+        Set<String> configurations = UserConfigurableValidator.getConfigurationNames();
+        assertFalse(configurations.contains("nonexistingConf"));
+        assertTrue(configurations.contains("mycompanypasspolicy"));
     }
 
     public void testUsernameValidator() {

--- a/webui/core/src/test/resources/conf/configuration.properties
+++ b/webui/core/src/test/resources/conf/configuration.properties
@@ -1,0 +1,10 @@
+gatein.validators.passwordpolicy.format.message=Minimum of 1 digit, 1 lower case, 1 upper case, minimum of 6 chars, max of 20.
+gatein.validators.passwordpolicy.regexp=((?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{6,20})
+gatein.validators.passwordpolicy.length.max=20
+gatein.validators.passwordpolicy.length.min=6
+
+gatein.validators.mycompanypasspolicy.format.message=Minimum of 1 digit, 1 lower case, 1 upper case, minimum of 6 chars, max of 20.
+gatein.validators.mycompanypasspolicy.regexp=((?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{6,20})
+gatein.validators.mycompanypasspolicy.length.max=20
+gatein.validators.mycompanypasspolicy.length.min=6
+

--- a/webui/eXo/src/main/java/org/exoplatform/webui/organization/UIAccountInputSet.java
+++ b/webui/eXo/src/main/java/org/exoplatform/webui/organization/UIAccountInputSet.java
@@ -30,7 +30,7 @@ import org.exoplatform.webui.core.UIApplication;
 import org.exoplatform.webui.form.UIFormInputWithActions;
 import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
+import org.exoplatform.webui.form.validator.PasswordPolicyValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
 import org.exoplatform.webui.form.validator.UserConfigurableValidator;
@@ -56,10 +56,10 @@ public class UIAccountInputSet extends UIFormInputWithActions {
                 UserConfigurableValidator.class, UserConfigurableValidator.USERNAME));
 
         addUIFormInput(new UIFormStringInput(PASSWORD1X, "password", null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30));
+                .addValidator(MandatoryValidator.class).addValidator(PasswordPolicyValidator.class));
 
         addUIFormInput(new UIFormStringInput(PASSWORD2X, "password", null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30));
+                .addValidator(MandatoryValidator.class).addValidator(PasswordPolicyValidator.class));
 
         addUIFormInput(new UIFormStringInput("firstName", "firstName", null).addValidator(StringLengthValidator.class, 1, 45)
                 .addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));

--- a/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountChangePass.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/account/UIAccountChangePass.java
@@ -42,7 +42,7 @@ import org.exoplatform.webui.event.EventListener;
 import org.exoplatform.webui.form.UIForm;
 import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
+import org.exoplatform.webui.form.validator.PasswordPolicyValidator;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -66,9 +66,9 @@ public class UIAccountChangePass extends UIForm {
         addUIFormInput(new UIFormStringInput("currentpass", "password", null).setType(UIFormStringInput.PASSWORD_TYPE)
                 .addValidator(MandatoryValidator.class));
         addUIFormInput(new UIFormStringInput("newpass", "password", null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(PasswordStringLengthValidator.class, 6, 30).addValidator(MandatoryValidator.class));
+                .addValidator(PasswordPolicyValidator.class).addValidator(MandatoryValidator.class));
         addUIFormInput(new UIFormStringInput("confirmnewpass", "password", null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(PasswordStringLengthValidator.class, 6, 30).addValidator(MandatoryValidator.class));
+                .addValidator(PasswordPolicyValidator.class).addValidator(MandatoryValidator.class));
         setActions(new String[] {"Save", "Reset", "ResetPass"});
     }
 

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/register/UIRegisterInputSet.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/register/UIRegisterInputSet.java
@@ -18,8 +18,6 @@
  */
 package org.exoplatform.portal.webui.register;
 
-import javax.portlet.PortletPreferences;
-
 import org.exoplatform.portal.webui.CaptchaValidator;
 import org.exoplatform.services.organization.Query;
 import org.exoplatform.services.organization.User;
@@ -32,10 +30,12 @@ import org.exoplatform.webui.core.UIApplication;
 import org.exoplatform.webui.form.UIFormInputWithActions;
 import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.validator.MandatoryValidator;
-import org.exoplatform.webui.form.validator.PasswordStringLengthValidator;
+import org.exoplatform.webui.form.validator.PasswordPolicyValidator;
 import org.exoplatform.webui.form.validator.PersonalNameValidator;
 import org.exoplatform.webui.form.validator.StringLengthValidator;
 import org.exoplatform.webui.form.validator.UserConfigurableValidator;
+
+import javax.portlet.PortletPreferences;
 
 /**
  * @author <a href="mailto:hoang281283@gmail.com">Minh Hoang TO</a>
@@ -72,10 +72,10 @@ public class UIRegisterInputSet extends UIFormInputWithActions {
                 UserConfigurableValidator.class, UserConfigurableValidator.USERNAME));
 
         addUIFormInput(new UIFormStringInput(PASSWORD, PASSWORD, null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30));
+                .addValidator(MandatoryValidator.class).addValidator(PasswordPolicyValidator.class));
 
         addUIFormInput(new UIFormStringInput(CONFIRM_PASSWORD, CONFIRM_PASSWORD, null).setType(UIFormStringInput.PASSWORD_TYPE)
-                .addValidator(MandatoryValidator.class).addValidator(PasswordStringLengthValidator.class, 6, 30));
+                .addValidator(MandatoryValidator.class).addValidator(PasswordPolicyValidator.class));
 
         addUIFormInput(new UIFormStringInput(FIRST_NAME, FIRST_NAME, null).addValidator(StringLengthValidator.class, 1, 45)
                 .addValidator(MandatoryValidator.class).addValidator(PersonalNameValidator.class));


### PR DESCRIPTION
Added the capability of setting custom password policies. If the configuration entry "passwordpolicy" is found on the configuration, it's then used for the password validation. Otherwise, it fallsback to the previous behavior, which is to validate that a password has a minimum of 6 chars and maximum of 30 chars.

Added a method on the UserConfigurableValidator that lists the currently known configuration entries for this validator, and a test for that.
