### PR TITLE
EXOGTN-2234 Don't collect Template statistics by default

### DIFF
--- a/component/scripting/src/main/java/org/exoplatform/groovyscript/text/TemplateService.java
+++ b/component/scripting/src/main/java/org/exoplatform/groovyscript/text/TemplateService.java
@@ -140,7 +140,7 @@ public class TemplateService implements Startable {
             @Override
             public void run() {
               templateStatistic.setResolver(resourceResolver);
-              // templateStatistic.setTime(time);
+              templateStatistic.setTime(time);
             }
           });
         }

--- a/component/scripting/src/main/java/org/exoplatform/groovyscript/text/TemplateService.java
+++ b/component/scripting/src/main/java/org/exoplatform/groovyscript/text/TemplateService.java
@@ -203,14 +203,11 @@ public class TemplateService {
     @Managed
     @ManagedDescription("Clear the template cache for a specified template identifier")
     @Impact(ImpactType.IDEMPOTENT_WRITE)
-    public String reloadTemplate(@ManagedDescription("The template id") @ManagedName("templateId") String name) {
+    public void reloadTemplate(@ManagedDescription("The template id") @ManagedName("templateId") String name) {
         TemplateStatistic app = statisticService.findTemplateStatistic(name);
         if (app != null) {
             ResourceResolver resolver = app.getResolver();
             templatesCache_.remove(resolver.createResourceKey(name));
-            return "Cleared";
-        } else {
-          return "Template can't be cleared";
         }
     }
 

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -178,6 +178,12 @@
 
   <component>
     <type>org.exoplatform.groovyscript.text.TemplateService</type>
+    <init-params>
+      <value-param>
+        <name>templates.collect.statistics</name>
+        <value>${exo.groovy.template.statistics.enable:false}</value>
+      </value-param>
+    </init-params>
   </component>
 
   <component>

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -181,7 +181,7 @@
     <init-params>
       <value-param>
         <name>templates.collect.statistics</name>
-        <value>${exo.groovy.template.statistics.enable:false}</value>
+        <value>${exo.groovy.template.statistics.enable:true}</value>
       </value-param>
     </init-params>
   </component>

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -181,7 +181,7 @@
     <init-params>
       <value-param>
         <name>templates.collect.statistics</name>
-        <value>${exo.groovy.template.statistics.enable:true}</value>
+        <value>${exo.statistics.groovy.template.enabled:true}</value>
       </value-param>
     </init-params>
   </component>


### PR DESCRIPTION
There is no way to disable the Groovy Template statistics collection. This PR make it disabled by default and allow to enable it by JMX or by parameter in exo.properties.
