### PR TITLE
when LDAP connection is down, throw the exception a upper level

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -742,6 +742,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
             log.debug("Can NOT find any user with username is NULL");
         } catch (Exception e) {
             handleException("Cannot obtain user: " + userName + "; ", e);
+            throw e;
         }
 
         if (u == null) {


### PR DESCRIPTION
Currently, when the ldap connection is down, the method getPopulatedUser return null, as when the ldap connection is up, and there is no user with this name.
To distinguish the 2 cases, we throw the exception at upper level