### PR TITLE
bcel dependency does not exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1225,7 +1225,7 @@ memory option properties. This should be removed when we can just set the compil
             <dependency>
               <groupId>org.apache.bcel</groupId>
               <artifactId>bcel</artifactId>
-              <version>6.0-SNAPSHOT</version>
+              <version>6.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
how can you compile using a third party dependency snapshot version? BCEL 6.0-SNAPSHOT doesn't exist. The 6.0 stable version is on the mvn repositories. Could you change it?