### PR TITLE
PLF-8270: prevent xss attack in initialURI of forgot password

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
@@ -103,7 +103,7 @@ public class PasswordRecoveryHandler extends WebRequestHandler {
         ResourceBundle bundle = bundleService.getResourceBundle(bundleService.getSharedResourceBundleNames(), locale);
 
         String token = context.getParameter(TOKEN);
-        String initURL = context.getParameter(INIT_URL);
+        String initURL = escapeXssCharacters(context.getParameter(INIT_URL));
 
         String requestAction = req.getParameter(REQ_PARAM_ACTION);
 


### PR DESCRIPTION
we escaped Xss Characters when we get INIT_URL parameter from url in order to prevent xss attack.