### PR TITLE
PLF-8590 Enhance CSRF check parameter in URL

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/security/csrf/CSRFTokenUtil.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/csrf/CSRFTokenUtil.java
@@ -33,7 +33,7 @@ import org.exoplatform.services.log.Log;
  *
  */
 public class CSRFTokenUtil {
-    public static final String CSRF_TOKEN = "gtn:csrf";
+    public static final String CSRF_TOKEN = "portal:csrf";
 
     protected static Log log = ExoLogger.getExoLogger(CSRFTokenUtil.class);
 


### PR DESCRIPTION
This modification applies new CSRF parameter naming that will avoid confusion made with '&gtn:csrf' that is converted into '>n:csrf' in some conditions