### PR TITLE
Upgrade to Hibernate 5

### DIFF
--- a/component/identity/pom.xml
+++ b/component/identity/pom.xml
@@ -40,17 +40,33 @@
           <groupId>org.hibernate</groupId>
           <artifactId>hibernate-core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-entitymanager</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.exoplatform.core</groupId>
       <artifactId>exo.core.component.organization.api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-entitymanager</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -157,6 +173,13 @@
       <!-- used only by byteman -->
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>5.4.10.Final</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/CustomHibernateServiceImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/CustomHibernateServiceImpl.java
@@ -28,11 +28,12 @@ import java.security.PrivilegedAction;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.service.BootstrapServiceRegistry;
-import org.hibernate.service.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
-import org.hibernate.service.internal.StandardServiceRegistryImpl;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 
 import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.xml.InitParams;
@@ -71,8 +72,8 @@ public class CustomHibernateServiceImpl extends HibernateServiceImpl {
 
         BootstrapServiceRegistry bootstrapRegistry = createHibernateBootstrapServiceRegistry();
 
-        final ServiceRegistry serviceRegistry = new ServiceRegistryBuilder(bootstrapRegistry).applySettings(
-                conf.getProperties()).buildServiceRegistry();
+        final ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder(bootstrapRegistry).applySettings(
+                conf.getProperties()).build();
         conf.setSessionFactoryObserver(new SessionFactoryObserver() {
             @Override
             public void sessionFactoryCreated(SessionFactory factory) {
@@ -94,8 +95,7 @@ public class CustomHibernateServiceImpl extends HibernateServiceImpl {
     protected BootstrapServiceRegistry createHibernateBootstrapServiceRegistry() {
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         ClassLoader hibernateCl = BootstrapServiceRegistry.class.getClassLoader();
-        return new BootstrapServiceRegistryBuilder().withApplicationClassLoader(tccl).withHibernateClassLoader(hibernateCl)
-                .build();
+        return new BootstrapServiceRegistryBuilder().with(tccl).with(hibernateCl).build();
     }
 
 }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserTransactionJtaPlatform.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserTransactionJtaPlatform.java
@@ -25,8 +25,8 @@ package org.exoplatform.services.organization.idm;
 
 import javax.transaction.UserTransaction;
 
-import org.hibernate.service.jndi.JndiException;
-import org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform;
+import org.hibernate.engine.jndi.JndiException;
+import org.hibernate.engine.transaction.jta.platform.internal.JBossAppServerJtaPlatform;
 
 // We need fallback to "java:jboss/UserTransaction" because "java:comp/UserTransaction" is not available
 // during eXo kernel boot in AS7 environment.


### PR DESCRIPTION
We tried to update hibernate-core up to 5.4.10.Final. Changed dependency and updated CustomHibernateServiceImpl, UserTransactionJtaPlatform in order to fit the new hibernate, but we ran into problems (java.lang.NoClassDefFoundError: org/hibernate/service/ServiceRegistryBuilder at org.exoplatform.services.database.impl.HibernateConfigurationImpl.buildSessionFactory(HibernateConfigurationImpl.java:48)). Then we tried to update exo.core.component.database.HibernateConfigurationImpl, but unforchantly, stalled due to lack of needed classes (didn't find a replacement for them (org.hibernate.cache.spi.GeneralDataRegion, org.hibernate.cache.spi.EntityRegion, org.hibernate.cache.spi.NaturalIdRegion, org.hibernate.cache.spi.CollectionRegion, org.hibernate.cache.spi.CacheDataDescription, org.hibernate.cache.spi.access.EntityRegionAccessStrategy)).