### PR TITLE
EXOGTN-2436 : Do not sanitize HTML when executing script on WebUI AJAX requests (#269)

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/PortalHttpRequest.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/PortalHttpRequest.js
@@ -409,7 +409,7 @@
       if (script == null || script == "")
         return;
       try {
-        eval($("<div />").html(script).text());
+        eval(script);
         return;
       } catch (err) {
         console.error(err.message);


### PR DESCRIPTION
When making AJAX requests with WebUI, if the response contains some scripts to execute (with JavascriptManager.addScripts(...)), the script content is HTML sanitized before being executed.
This sanitization is not necessary and does not allow to have HTML tags in the script (for example in js strings).

This fix removes the sanitization.