### PR TITLE
EXOGTN-2436 : unescape WebUI AJAX scripts before executing them

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/PortalHttpRequest.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/PortalHttpRequest.js
@@ -137,7 +137,8 @@
     });
     // Portal Response Script
     div.children("div.PortalResponseScript").each(function() {
-      portalResp.script = this.innerHTML;
+      // Unescape \" in scripts to make sure JSON snippets are correctly formatted
+      portalResp.script = this.innerHTML.replace(/"\\&quot;/g, '\\"').replace(/\\&quot;"/g, '\\"');
       $(this).css("display", "none");
     });
   }
@@ -409,7 +410,10 @@
       if (script == null || script == "")
         return;
       try {
-        eval(script);
+        // Set script in textarea to decode HTML entities without removing HTML tags
+        let textarea = document.createElement("textarea");
+        textarea.innerHTML = script;
+        eval(textarea.value);
         return;
       } catch (err) {
         console.error(err.message);


### PR DESCRIPTION
When WebUI AJAX scripts are executed they must be decoded before to make sure HTML entities are correctly decoded.
This was previously done with JQuery, but JQuery also remove HTML tags in the script, which caused others issues.
Using a textarea allows to decode entities without removing tags.

A change has also been introduced to handle a specific case : when the script contains a JSON object with double quotes, such as { "description" : "My <a href=\"http://google.com\">description</a>" }, the characters \" are changed to "\&quote; before the execution of the script. This makes the script execution to fail.
The fix replace these characters before executing the script.

######
I did not find a better solution for the second change. I discovered this case in Webconfecenring addon which passes the providers description in WebUI AJAX scripts in JSON, and these descriptions contain HTML : https://github.com/exo-addons/web-conferencing/blob/develop/webrtc/services/src/main/resources/locale/webrtc/WebRTCAdmin_en.xml#L5
Is someone has a better solution, I would be happy to apply it !