### PR TITLE
Fix for the incompatibility of default versions of Mockito and PowerMock

### DIFF
--- a/component/web/oauth-common/pom.xml
+++ b/component/web/oauth-common/pom.xml
@@ -131,11 +131,19 @@
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-oauth2</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Mockito 1.8.5 and PowerMock 1.6.5 are not compatible and a ClassNotFoundException is thrown during tests.
This fix import Mockito-all with the right version to avoid using managed Mockito version (1.8.5)