### PR TITLE
Deactive cache usage during setEnable function (#35)

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableUserHandlerImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableUserHandlerImpl.java
@@ -145,9 +145,14 @@ public class CacheableUserHandlerImpl extends UserDAOImpl {
    * {@inheritDoc}
    */
   public User setEnabled(String userName, boolean enabled, boolean broadcast) throws Exception {
-    User result = super.setEnabled(userName, enabled, broadcast);
-    userCache.remove(userName);
-    return result;
+    disableCacheInThread.set(true);
+    try {
+      User result = super.setEnabled(userName, enabled, broadcast);
+      userCache.remove(userName);
+      return result;
+    } finally {
+      disableCacheInThread.set(false);
+    }
   }
 
   /**


### PR DESCRIPTION
If we don't deactivate cache, in user event listeners like preEnable and postEnable, the cache could have a false value