### PR TITLE
Allow to override hibernate.hbm2ddl.auto property

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -62,7 +62,7 @@
       <properties-param>
         <name>hibernate.properties</name>
         <description>Default Hibernate Service</description>
-        <property name="hibernate.hbm2ddl.auto" value="update"/>
+        <property name="hibernate.hbm2ddl.auto" value="${exo.idm.hibernate.hbm2ddl:update}"/>
         <property name="hibernate.show_sql" value="false"/>
         <property name="hibernate.connection.datasource" value="${gatein.idm.datasource.name}${container.name.suffix}"/>
         <property name="hibernate.connection.autocommit" value="false"/>


### PR DESCRIPTION
`hibernate.hbm2ddl.auto` should be set to `none`, thus we define a property to allow turn off DB schema update in production